### PR TITLE
Use `nodejs14.x` instead of `nodejs10.x`.

### DIFF
--- a/cloudformation/distribution.yaml
+++ b/cloudformation/distribution.yaml
@@ -184,7 +184,7 @@ Resources:
     Type: AWS::Serverless::Function
     Condition: ApplyIndexDocument
     Properties:
-      Runtime: nodejs10.x # Maximum version supported by Lambda@Edge
+      Runtime: nodejs14.x # Maximum version supported by Lambda@Edge
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt LambdaEdgeRole.Arn
@@ -206,7 +206,7 @@ Resources:
     Type: AWS::Serverless::Function
     Condition: ApplyDomainRedirect
     Properties:
-      Runtime: nodejs10.x # Maximum version supported by Lambda@Edge
+      Runtime: nodejs14.x # Maximum version supported by Lambda@Edge
       Handler: index.handler
       MemorySize: 128
       Role: !GetAtt LambdaEdgeRole.Arn

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-website-template",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Serverless website template, for use as boilerplate to deploy to AWS S3, CloudFront, Lambda and CloudFormation",
   "author": "Ben New <ben@leftclick.com.au>",
   "license": "MIT",


### PR DESCRIPTION
https://aws.amazon.com/about-aws/whats-new/2021/04/lambda-edge-support-node14/

Better late than never.